### PR TITLE
Add simple React single page setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # FirstAIProject
-Asked Codex by OpenAI to create this project
+
+This is a simple single-page setup that uses React via CDN. Open `index.html` in a browser to see the example app.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>React Single Page</title>
+    <!-- React and Babel CDN -->
+    <script crossorigin src="https://unpkg.com/react@17/umd/react.development.js"></script>
+    <script crossorigin src="https://unpkg.com/react-dom@17/umd/react-dom.development.js"></script>
+    <script crossorigin src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+</head>
+<body>
+    <div id="root"></div>
+
+    <script type="text/babel">
+        function App() {
+            return (
+                <div>
+                    <h1>Hello, React!</h1>
+                    <p>This is a simple single page setup for developing React UI.</p>
+                </div>
+            );
+        }
+
+        ReactDOM.render(<App />, document.getElementById('root'));
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a single `index.html` that loads React from a CDN and renders a basic component
- update README with brief instructions

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_684026f20ee083249bd12d86197b2a4f